### PR TITLE
Adding Docker and Nginx configs to containerize bibtex-tidy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:16 AS builder
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+
+# Bundle app source
+COPY ./src ./src
+COPY ./docs ./docs
+COPY ./build.ts .
+COPY ./tsconfig.json .
+COPY ./README.md .
+RUN mkdir bin
+
+RUN npm run build
+
+FROM nginx:alpine
+
+WORKDIR /usr/src/app
+COPY --from=builder /usr/src/app/docs ./docs
+
+# Copy a new configuration file setting listen port to 8080
+COPY ./bibtex-tidy.conf /etc/nginx/conf.d/
+
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/bibtex-tidy.conf
+++ b/bibtex-tidy.conf
@@ -1,0 +1,17 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    location / {
+        root   /usr/src/app/docs;
+        index  index.html;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+
+services:
+  bibtex-tidy:
+    image: bibtex-tidy
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+


### PR DESCRIPTION
Adding Docker and Nginx configs to containerize bibtex-tidy for self-hosted web deployment at http://localhost:8080