### PR TITLE
Fix --sort-fields  CLI output

### DIFF
--- a/bibtex-tidy.js
+++ b/bibtex-tidy.js
@@ -4214,7 +4214,7 @@ var optionDefinitions = [
     toCLI: (val) => {
       if (Array.isArray(val) && val.length > 0) {
         if (JSON.stringify(val) === JSON.stringify(DEFAULT_FIELD_SORT)) {
-          return "--sort_fields";
+          return "--sort-fields";
         }
         return "--sort-fields=".concat(val.join(","));
       }

--- a/bin/bibtex-tidy
+++ b/bin/bibtex-tidy
@@ -502,7 +502,7 @@ var optionDefinitions = [
     toCLI: (val) => {
       if (Array.isArray(val) && val.length > 0) {
         if (JSON.stringify(val) === JSON.stringify(DEFAULT_FIELD_SORT)) {
-          return "--sort_fields";
+          return "--sort-fields";
         }
         return `--sort-fields=${val.join(",")}`;
       }

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -6060,7 +6060,7 @@ var __generator =
         key: "sortFields",
         cli: { "--sort-fields": (r) => (r.length > 0 ? r : !0) },
         toCLI: (r) => {
-          if (Array.isArray(r) && r.length > 0) return JSON.stringify(r) === JSON.stringify(fo) ? "--sort_fields" : "--sort-fields=".concat(r.join(","));
+          if (Array.isArray(r) && r.length > 0) return JSON.stringify(r) === JSON.stringify(fo) ? "--sort-fields" : "--sort-fields=".concat(r.join(","));
           if (r === !0) return "--sort-fields";
         },
         title: "Sort fields",

--- a/src/optionDefinitions.ts
+++ b/src/optionDefinitions.ts
@@ -314,7 +314,7 @@ export const optionDefinitions: OptionDefinition[] = [
 		toCLI: (val) => {
 			if (Array.isArray(val) && val.length > 0) {
 				if (JSON.stringify(val) === JSON.stringify(DEFAULT_FIELD_SORT)) {
-					return '--sort_fields';
+					return '--sort-fields';
 				}
 				return `--sort-fields=${val.join(',')}`;
 			}


### PR DESCRIPTION
Hi,

first of all thank you for this tool, really nice to quickly interactively test it before buying into it :+1: 

The CLI output shows `--sort_fields` with an underscore where it has to be `--sort-fields` with a dash/minus, i.e. the command from the CLI wont work or to be more precise: error with `Unknown option: --sort_fields`

![image](https://user-images.githubusercontent.com/31306376/226727591-75cdcb27-eafd-40ce-ba86-6c74f65ee7f9.png)

I searched the repo for `--sort_fields`, fixed the instance under `./src` and ran `npm run build`. 

I wanted to run the docker instructions locally but ran into a 
```
 [ERROR] fetch is not defined [plugin google-font-loader]
```
during `Step 11/17 : RUN npm run build` (note it ran fine as a standalone command in the repo). I have absolutely no clue of the languages etc so I stopped trying to get it to run after 15min or so. I also only really found [this very recent related github issue](https://github.com/vercel/next.js/issues/45080). I am on EndeavourOS with `node --version = v19.8.1` in case

In the `contributing guidelines` it says one should run `npm build` which fails on my system
```bash
[tobi@tobiT480 bibtex-tidy]$ npm build
Unknown command: "build"
```
but `npm run build` works. So either that has to be changed or it is some version-dependent thing.

Let me know whether this PR is fine :)