### PR TITLE
fix: crash on Node < 26 due to missing WeakMap getOrInsert polyfill

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -2,3 +2,4 @@ import "core-js/modules/es.array.flat-map";
 import "core-js/modules/es.object.from-entries";
 import "core-js/modules/es.string.trim-end";
 import "core-js/modules/es.map.get-or-insert";
+import "core-js/modules/es.weak-map.get-or-insert";


### PR DESCRIPTION
This is from an AI-agent, but it worked for me:

fix: polyfill WeakMap.prototype.getOrInsert for Node < 26

removeDuplicateFields uses WeakMap#getOrInsert, but polyfills.ts only
imported the Map variant. The method is native from V8 14.6 / Node 26,
so every tidy crashed on older supported Node versions with
"TypeError: seenFieldsByEntry.getOrInsert is not a function".